### PR TITLE
feat: support reading windows from all screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ EnumWindows.xcodeproj/xcuserdata/
 *.un~
 EnumWindows/EnumWindows
 xcuserdata/
+build
+SwiftWindowSwitcher.alfredworkflow
+AlfredWorkflow/EnumWindows
+.DS_Store

--- a/AlfredWorkflow/info.plist
+++ b/AlfredWorkflow/info.plist
@@ -465,27 +465,9 @@ end extract_argv</string>
 
 set argv to extract_argv(q, &quot;|||||&quot;)
 
-set proc to item 1 of argv
 set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
 
-if proc is not &quot;iTerm&quot; then
-	display alert &quot;This AppleScript works for iTerm only.&quot; message &quot;Check the Alfred workflow diagram which triggered this script.&quot; as critical buttons {&quot;Cancel&quot;} default button &quot;Cancel&quot; cancel button &quot;Cancel&quot;
-end if
-
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			-- nb. iTerm&apos;s process is &quot;iTerm2&quot; even though application name is &quot;iTerm&quot;
-			tell process &quot;iTerm2&quot; to perform action &quot;AXRaise&quot; of window windowName
-		end timeout
-	end tell
-end try
-
-tell application &quot;iTerm&quot;
-	activate
-end tell
-
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
 
 tell front window of application &quot;iTerm&quot;
 	tell tab tabIndex
@@ -549,19 +531,8 @@ set argv to extract_argv(q, &quot;|||||&quot;)
 
 set proc to item 1 of argv
 set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
 
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			tell process proc to perform action &quot;AXRaise&quot; of window windowName 
-		end timeout
-	end tell
-end try
-
-tell application proc
-    activate
-end tell
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
 
 if proc = &quot;Safari Technology Preview&quot; then
     tell front window of application &quot;Safari Technology Preview&quot;
@@ -716,19 +687,8 @@ set argv to extract_argv(q, &quot;|||||&quot;)
 
 set proc to item 1 of argv
 set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
 
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			tell process proc to perform action &quot;AXRaise&quot; of window windowName 
-		end timeout
-	end tell
-end try
-
-tell application proc
-    activate
-end tell
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
 
 if proc = &quot;Safari&quot; then
     tell front window of application &quot;Safari&quot;
@@ -763,25 +723,11 @@ end extract_argv</string>
 
 set argv to extract_argv(q, &quot;|||||&quot;)
 
-set proc to item 1 of argv
 set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
 
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			tell process proc to perform action &quot;AXRaise&quot; of window windowName 
-		end timeout
-	end tell
-end try
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
 
-tell application proc
-    activate
-end tell
-
-if proc = &quot;Opera&quot; then
-	tell application &quot;Opera&quot; to set active tab index of front window to tabIndex
-end if
+tell application &quot;Opera&quot; to set active tab index of front window to tabIndex
 
 end alfred_script
 
@@ -826,34 +772,8 @@ end extract_argv</string>
 			<dict>
 				<key>applescript</key>
 				<string>on alfred_script(q)
-
-set argv to extract_argv(q, &quot;|||||&quot;)
-
-set proc to item 1 of argv
-set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
-
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			tell process proc to perform action &quot;AXRaise&quot; of window windowName 
-		end timeout
-	end tell
-end try
-
-tell application proc
-    activate
-end tell
-
-end alfred_script
-
-on extract_argv(source_string, new_delimiter)
-	set backup to AppleScript&apos;s text item delimiters
-	set AppleScript&apos;s text item delimiters to new_delimiter
-	set argv to every text item of source_string
-	set AppleScript&apos;s text item delimiters to backup
-	return argv
-end extract_argv</string>
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
+end alfred_script</string>
 				<key>cachescript</key>
 				<true/>
 			</dict>
@@ -891,25 +811,11 @@ end extract_argv</string>
 
 set argv to extract_argv(q, &quot;|||||&quot;)
 
-set proc to item 1 of argv
 set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
 
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			tell process proc to perform action &quot;AXRaise&quot; of window windowName 
-		end timeout
-	end tell
-end try
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
 
-tell application proc
-    activate
-end tell
-
-if proc = &quot;Opera Beta&quot; then
-	tell application &quot;Opera Beta&quot; to set active tab index of front window to tabIndex
-end if
+tell application &quot;Opera Beta&quot; to set active tab index of front window to tabIndex
 
 end alfred_script
 
@@ -938,25 +844,11 @@ end extract_argv</string>
 
 set argv to extract_argv(q, &quot;|||||&quot;)
 
-set proc to item 1 of argv
 set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
 
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			tell process proc to perform action &quot;AXRaise&quot; of window windowName 
-		end timeout
-	end tell
-end try
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
 
-tell application proc
-    activate
-end tell
-
-if proc = &quot;Opera Developer&quot; then
-	tell application &quot;Opera Developer&quot; to set active tab index of front window to tabIndex
-end if
+tell application &quot;Opera Developer&quot; to set active tab index of front window to tabIndex
 
 end alfred_script
 
@@ -1004,25 +896,11 @@ end extract_argv</string>
 
 set argv to extract_argv(q, &quot;|||||&quot;)
 
-set proc to item 1 of argv
 set tabIndex to item 2 of argv as integer
-set windowName to item 3 of argv
 
-try
-	tell application &quot;System Events&quot;
-		with timeout of 0.1 seconds
-			tell process proc to perform action &quot;AXRaise&quot; of window windowName 
-		end timeout
-	end tell
-end try
+do shell script "/Users/vivaxy/SynologyDrive/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AB9F25DE-E233-44F0-A8DE-D047D6C14F6E/EnumWindows --activate=" &amp; quoted form of q
 
-tell application proc
-    activate
-end tell
-
-if proc = &quot;Brave Browser&quot; then
-	tell application &quot;Brave Browser&quot; to set active tab index of front window to tabIndex
-end if
+tell application &quot;Brave Browser&quot; to set active tab index of front window to tabIndex
 
 end alfred_script
 

--- a/EnumWindows.xcodeproj/project.pbxproj
+++ b/EnumWindows.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		7439217F1E5DE92100720BFB /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7439217E1E5DE92100720BFB /* AppIcon.swift */; };
 		743921811E5DEDF100720BFB /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 743921801E5DEDF100720BFB /* AppKit.framework */; };
 		74466BA51E5760FB0032382F /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74466BA41E5760FB0032382F /* ScriptingBridge.framework */; };
+		74SKYLT001E53270300C78C58 /* SkyLight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74SKYLT011E53270300C78C58 /* SkyLight.framework */; };
 		74466BA71E5761F90032382F /* BrowserApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74466BA61E5761F90032382F /* BrowserApplication.swift */; };
 		744970C41E5397C60088C63C /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744970C31E5397C60088C63C /* Windows.swift */; };
 		744970C61E5397F30088C63C /* Alfred.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744970C51E5397F30088C63C /* Alfred.swift */; };
@@ -37,6 +38,7 @@
 		7439217E1E5DE92100720BFB /* AppIcon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		743921801E5DEDF100720BFB /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		74466BA41E5760FB0032382F /* ScriptingBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScriptingBridge.framework; path = System/Library/Frameworks/ScriptingBridge.framework; sourceTree = SDKROOT; };
+		74SKYLT011E53270300C78C58 /* SkyLight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SkyLight.framework; path = System/Library/PrivateFrameworks/SkyLight.framework; sourceTree = SDKROOT; };
 		74466BA61E5761F90032382F /* BrowserApplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserApplication.swift; sourceTree = "<group>"; };
 		744970C31E5397C60088C63C /* Windows.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Windows.swift; sourceTree = "<group>"; };
 		744970C51E5397F30088C63C /* Alfred.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alfred.swift; sourceTree = "<group>"; };
@@ -55,6 +57,7 @@
 			files = (
 				743921811E5DEDF100720BFB /* AppKit.framework in Frameworks */,
 				74466BA51E5760FB0032382F /* ScriptingBridge.framework in Frameworks */,
+				74SKYLT001E53270300C78C58 /* SkyLight.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +77,7 @@
 			children = (
 				743921801E5DEDF100720BFB /* AppKit.framework */,
 				74466BA41E5760FB0032382F /* ScriptingBridge.framework */,
+				74SKYLT011E53270300C78C58 /* SkyLight.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -283,6 +287,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				DEVELOPMENT_TEAM = LADJFGFXHV;
+				OTHER_LDFLAGS = "-F/System/Library/PrivateFrameworks -framework SkyLight";
 				PRODUCT_BUNDLE_IDENTIFIER = ru.mandrigin.EnumWindows;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
@@ -295,6 +300,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				DEVELOPMENT_TEAM = LADJFGFXHV;
+				OTHER_LDFLAGS = "-F/System/Library/PrivateFrameworks -framework SkyLight";
 				PRODUCT_BUNDLE_IDENTIFIER = ru.mandrigin.EnumWindows;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;

--- a/EnumWindows/Alfred.swift
+++ b/EnumWindows/Alfred.swift
@@ -4,15 +4,17 @@ struct AlfredArg {
     private let arg1 : String
     private let arg2 : String
     private let arg3 : String
-    
-    init(arg1: String, arg2: String, arg3: String) {
+    private let arg4 : String
+
+    init(arg1: String, arg2: String, arg3: String, arg4: String = "") {
         self.arg1 = arg1
         self.arg2 = arg2
         self.arg3 = arg3
+        self.arg4 = arg4
     }
-    
+
     var serialized : String {
-        return "\(self.arg1)|||||\(self.arg2)|||||\(self.arg3)"
+        return "\(self.arg1)|||||\(self.arg2)|||||\(self.arg3)|||||\(self.arg4)"
     }
 }
 

--- a/EnumWindows/AlfredItems.swift
+++ b/EnumWindows/AlfredItems.swift
@@ -5,7 +5,7 @@ extension WindowInfoDict : AlfredItem {
     var autocomplete : String { return self.name };
     var title : String { return self.name };
     var subtitle : String { return "Process: \(self.processName) | App name: \(self.processName)" };
-    var arg: AlfredArg { return AlfredArg(arg1:self.processName, arg2:"\(self.tabIndex)", arg3:self.title) }
+    var arg: AlfredArg { return AlfredArg(arg1:self.processName, arg2:"\(self.tabIndex)", arg3:self.title, arg4:"\(self.number)") }
 }
 
 extension BrowserTab : AlfredItem {

--- a/EnumWindows/CommandLine+EnumWindows.swift
+++ b/EnumWindows/CommandLine+EnumWindows.swift
@@ -34,7 +34,17 @@ struct SearchCommand : CommmandLineCommand {
     internal static var name: String { return "--search" }
 
     let query : String;
-    
+
+    init(value: String) {
+        self.query = value
+    }
+}
+
+struct ActivateCommand : CommmandLineCommand {
+    internal static var name: String { return "--activate" }
+
+    let query : String;
+
     init(value: String) {
         self.query = value
     }
@@ -47,6 +57,7 @@ extension CommandLine {
         for arg in self.arguments {
             result.append(SearchCommand.fromArgv(argv: arg))
             result.append(OnlyTabsCommand.fromArgv(argv: arg))
+            result.append(ActivateCommand.fromArgv(argv: arg))
         }
         return result.flatMap { (command: CommmandLineCommand?) -> [CommmandLineCommand] in
             guard let c = command else { return [] }

--- a/EnumWindows/Windows.swift
+++ b/EnumWindows/Windows.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreGraphics
 
 class WindowInfoDict : Searchable, ProcessNameProtocol {
     private let windowInfoDict : Dictionary<NSObject, AnyObject>;
@@ -101,19 +102,19 @@ struct Windows {
 
     static var all : [WindowInfoDict] {
         get {
-            guard let wl = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) else {
+            guard let wl = CGWindowListCopyWindowInfo([.optionAll, .excludeDesktopElements], kCGNullWindowID) else {
                 return []
             }
-            
+
             return (0..<CFArrayGetCount(wl)).flatMap { (i : Int) -> [WindowInfoDict] in
                 guard let windowInfoRef = CFArrayGetValueAtIndex(wl, i) else {
                     return []
                 }
-                
+
                 let wi = WindowInfoDict(rawDict: windowInfoRef)
-                
+
                 // We don't want to clutter our output with unnecessary windows that we can't switch to anyway.
-                guard !wi.name.isEmpty && !wi.isProbablyMenubarItem && wi.isVisible else {
+                guard !wi.name.isEmpty && !wi.isProbablyMenubarItem && wi.isVisible && !wi.bounds.isEmpty else {
                     return []
                 }
                 

--- a/EnumWindows/main.swift
+++ b/EnumWindows/main.swift
@@ -1,4 +1,27 @@
 import Foundation
+import CoreGraphics
+import AppKit
+import ApplicationServices
+
+// MARK: - CGS private API (for cross-Space window activation)
+
+typealias CGSConnectionID = UInt32
+typealias CGSSpaceID = UInt64
+
+@_silgen_name("CGSMainConnectionID")
+func CGSMainConnectionID() -> CGSConnectionID
+
+/// Returns the space IDs for the given window IDs. mask 7 = all spaces.
+@_silgen_name("CGSCopySpacesForWindows")
+func CGSCopySpacesForWindows(_ cid: CGSConnectionID, _ mask: Int, _ wids: CFArray) -> CFArray
+
+/// Returns an array of display dictionaries, each with a "Spaces" array and "Display Identifier".
+@_silgen_name("CGSCopyManagedDisplaySpaces")
+func CGSCopyManagedDisplaySpaces(_ cid: CGSConnectionID) -> CFArray
+
+/// Switches the active space on the given display to sid. No slide animation.
+@_silgen_name("CGSManagedDisplaySetCurrentSpace")
+func CGSManagedDisplaySetCurrentSpace(_ cid: CGSConnectionID, _ display: CFString, _ sid: CGSSpaceID) -> Void
 
 /// Removes browser window from the list of windows and adds tabs to the results array
 func searchBrowserTabsIfNeeded(processName: String,
@@ -42,6 +65,92 @@ func search(query: String, onlyTabs: Bool) {
     print(AlfredDocument(withItems: alfredItems).xml.xmlString)
 }
 
+func activate(arg: String) {
+    let parts = arg.components(separatedBy: "|||||")
+    guard !parts.isEmpty else { return }
+    let windowId = parts.count > 3 ? UInt32(parts[3]) ?? 0 : 0
+
+    if windowId > 0 {
+        // Look up app by PID from CGWindowListCopyWindowInfo — same data source as the
+        // search step, and unambiguous unlike localizedName vs kCGWindowOwnerName.
+        let allWindows = CGWindowListCopyWindowInfo(
+            [.optionAll, .excludeDesktopElements], kCGNullWindowID
+        ) as? [[String: Any]] ?? []
+        let windowInfo = allWindows.first {
+            ($0[kCGWindowNumber as String] as? UInt32) == windowId
+        }
+        guard let ownerPid = windowInfo?[kCGWindowOwnerPID as String] as? pid_t,
+              let app = NSWorkspace.shared.runningApplications
+                  .first(where: { $0.processIdentifier == ownerPid })
+        else { return }
+
+        // Get window title for AX matching (AXWindowID fails with -25205 after space switch).
+        let targetTitle = windowInfo?[kCGWindowName as String] as? String ?? ""
+
+        let cid = CGSMainConnectionID()
+
+        // Find which space this window lives on (mask 7 = all spaces).
+        let spaceIds = CGSCopySpacesForWindows(cid, 7, [windowId] as CFArray) as! [CGSSpaceID]
+        if let targetSpaceId = spaceIds.first {
+            // Find the display UUID that owns this space.
+            var targetDisplay: CFString? = nil
+            let displaySpaces = CGSCopyManagedDisplaySpaces(cid) as! [[String: Any]]
+            outer: for screen in displaySpaces {
+                guard let spaces = screen["Spaces"] as? [[String: Any]] else { continue }
+                for space in spaces {
+                    if let sid = space["id64"] as? CGSSpaceID, sid == targetSpaceId {
+                        var display = screen["Display Identifier"] as! CFString
+                        // "Main" is a sentinel on single-display setups — map to real UUID.
+                        if (display as String) == "Main" {
+                            if let mainScreen = NSScreen.main,
+                               let screenNumber = mainScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+                               let uuidRef = CGDisplayCreateUUIDFromDisplayID(screenNumber) {
+                                display = CFUUIDCreateString(nil, uuidRef.takeRetainedValue())!
+                            }
+                        }
+                        targetDisplay = display
+                        break outer
+                    }
+                }
+            }
+
+            // Switch to the target space (no slide animation, but space does change).
+            if let display = targetDisplay {
+                CGSManagedDisplaySetCurrentSpace(cid, display, targetSpaceId)
+                // Wait for the space context to propagate before AX queries.
+                Thread.sleep(forTimeInterval: 0.5)
+            }
+        }
+
+        // Activate the app, then AXRaise the specific window.
+        app.activate(options: [.activateIgnoringOtherApps])
+        Thread.sleep(forTimeInterval: 0.3)
+
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        var windowsRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+           let windows = windowsRef as? [AXUIElement] {
+            for window in windows {
+                // Match by title instead of AXWindowID (which fails with -25205 after space switch).
+                var titleRef: CFTypeRef?
+                if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success,
+                   let axTitle = titleRef as? String,
+                   axTitle == targetTitle, !targetTitle.isEmpty {
+                    AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+                    break
+                }
+            }
+        }
+        return
+    }
+
+    // Fallback: no windowId, activate by processName.
+    let processName = parts[0]
+    guard let app = NSWorkspace.shared.runningApplications
+        .first(where: { $0.localizedName == processName }) else { return }
+    app.activate(options: [.activateIgnoringOtherApps])
+}
+
 func handleCatalinaScreenRecordingPermission() {
     guard let firstWindow = Windows.any else {
         return
@@ -51,6 +160,7 @@ func handleCatalinaScreenRecordingPermission() {
         return
     }
 
+    #if !os(macOS) || swift(<5.9)
     let windowImage = CGWindowListCreateImage(.null, .optionIncludingWindow,
                                               firstWindow.number,
                                               [.boundsIgnoreFraming, .bestResolution])
@@ -58,7 +168,14 @@ func handleCatalinaScreenRecordingPermission() {
         debugPrint("Before using this app, you need to give permission in System Preferences > Security & Privacy > Privacy > Screen Recording.\nPlease authorize and re-launch.")
         exit(1)
     }
+    #else
+    // On macOS 15+, CGWindowListCreateImage is unavailable; the OS handles Screen Recording permission prompts automatically.
+    debugPrint("Before using this app, you need to give permission in System Preferences > Security & Privacy > Privacy > Screen Recording.\nPlease authorize and re-launch.")
+    exit(1)
+    #endif
 }
+
+NSApplication.shared.setActivationPolicy(.accessory)
 
 handleCatalinaScreenRecordingPermission()
 
@@ -92,6 +209,9 @@ for command in CommandLine.commands() {
         exit(0)
     case let searchCommand as OnlyTabsCommand:
         search(query: searchCommand.query, onlyTabs: true)
+        exit(0)
+    case let activateCommand as ActivateCommand:
+        activate(arg: activateCommand.query)
         exit(0)
     default:
         print("Unknown command!")

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build bundle install
+
+bundle: build
+	cp build/Release/EnumWindows AlfredWorkflow/
+	cd AlfredWorkflow && zip -r ../SwiftWindowSwitcher.alfredworkflow info.plist icon.png switch.png EnumWindows
+
+build:
+	xcodebuild -project EnumWindows.xcodeproj \
+		-target EnumWindows \
+		-configuration Release \
+		CODE_SIGN_IDENTITY="" \
+		CODE_SIGNING_REQUIRED=NO \
+		CODE_SIGNING_ALLOWED=NO
+
+install: bundle
+	open SwiftWindowSwitcher.alfredworkflow


### PR DESCRIPTION
- add CoreGraphics import and handle macOS 15+ screen recording permission
- Add explicit CoreGraphics imports to Windows.swift and main.swift
- Switch window list option from .optionOnScreenOnly to .optionAll
- Add bounds.isEmpty guard to filter zero-size windows
- Wrap deprecated CGWindowListCreateImage in compile-time conditional for macOS 15+ compatibility

resolve #11, #37